### PR TITLE
Fixed --to format bug in name-value-get

### DIFF
--- a/name_value/applications/name-value-get.cpp
+++ b/name_value/applications/name-value-get.cpp
@@ -246,7 +246,7 @@ int main( int ac, char** av )
         else if( to == "json" ) { output = &traits< json >::output; }
         else if( to == "xml" ) { output = &traits< xml >::output; }
         else if( to == "path-value" ) { output = &traits< path_value >::output; }
-        else if( to == "name-value" ) { output = &traits< path_value >::output; }
+        else if( to == "name-value" ) { output = &traits< name_value >::output; }
         if( linewise )
         {
             comma::signal_flag is_shutdown;


### PR DESCRIPTION
When --to field was set to name-value, the output was being set incorrectly
to the path_value writer.
